### PR TITLE
Use the last version of BuildTools & New Spigot version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ name=empty-spigot-plugin
 version=2.0.0
 
 apitype=SPIGOT
-apiversion=1.8.7-R0.1-SNAPSHOT
-apibuildtoolversion=1.8.7
+apiversion=1.9.4-R0.1-SNAPSHOT
+apibuildtoolversion=1.9.4
 
 sourceversion=1.7
 
-buildtoolurl=https://hub.spigotmc.org/jenkins/job/BuildTools/40/artifact/target/BuildTools.jar
+buildtoolurl=https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar


### PR DESCRIPTION
I updated the gradle.properties that the last version of BuildTools is automatically used and you do not have to update it manually. I also updated the Spigot version there to v 1.9.4.
