### PR TITLE
Make Build (IntelliJ Runconfig) use the correct Gradletask

### DIFF
--- a/config/intellij_runconfigs.txt
+++ b/config/intellij_runconfigs.txt
@@ -28,7 +28,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="copyPluginToBukkit" />
+          <option value="copyPluginToTestserver" />
         </list>
       </option>
       <option name="vmOptions" value="" />


### PR DESCRIPTION
Now the build IntelliJ-Runconfig uses the correct Gradletask to build the plugin and copy the plugin.jar to the correct test-server directory.
